### PR TITLE
Add TCRconvert and TCRconvertR tools to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ https://hla.alleles.org/nomenclature/index.html
 
 ### Allele Frequency Net Database
 
-http://www.allelefrequencies.net/
+http://www.allelefrequencies.net/collaborators.asp
 
 > AFND is a public resource that collects information on allele, genotype and haplotype frequencies from different polymorphic areas in the human genome such as human leukocyte antigens (HLA), killer-cell immunoglobulin-like receptors, etc. To produce this database we have compiled a large collection of datasets from different sources including: (i) peer-reviewed literature, (ii) datasets from international workshops in immunogenetics and histocompatiblity and (iii) data submitted directly to AFND by individual laboratories. As more than 75% of the submissions in AFND are derived from peer-review literature, we rely upon data verification by journal editors and reviewers when source studies are published.
 

--- a/README.md
+++ b/README.md
@@ -502,8 +502,6 @@ https://hla.alleles.org/nomenclature/index.html
 
 ### Allele Frequency Net Database
 
-http://www.allelefrequencies.net/collaborators.asp
-
 > AFND is a public resource that collects information on allele, genotype and haplotype frequencies from different polymorphic areas in the human genome such as human leukocyte antigens (HLA), killer-cell immunoglobulin-like receptors, etc. To produce this database we have compiled a large collection of datasets from different sources including: (i) peer-reviewed literature, (ii) datasets from international workshops in immunogenetics and histocompatiblity and (iii) data submitted directly to AFND by individual laboratories. As more than 75% of the submissions in AFND are derived from peer-review literature, we rely upon data verification by journal editors and reviewers when source studies are published.
 
 Gonzalez-Galarza FF, McCabe A, Santos EJMD, Jones J, Takeshita L, Ortega-Rivera ND, et al. [Allele frequency net database (AFND) 2020 update: gold-standard data classification, open access genotype data and new query tools.](https://pubmed.ncbi.nlm.nih.gov/31722398/) Nucleic Acids Res. 2020;48: D783–D788. doi:10.1093/nar/gkz1029

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Python package
 
 https://presto.readthedocs.io/en/stable
 
-https://bitbucket.org/kleinstein/presto
+https://github.com/immcantation/presto
 
 > pRESTO is a toolkit for processing raw reads from high-throughput sequencing of B cell and T cell repertoires.
 > 

--- a/README.md
+++ b/README.md
@@ -502,6 +502,8 @@ https://hla.alleles.org/nomenclature/index.html
 
 ### Allele Frequency Net Database
 
+http://www.allelefrequencies.net/collaborators.asp
+
 > AFND is a public resource that collects information on allele, genotype and haplotype frequencies from different polymorphic areas in the human genome such as human leukocyte antigens (HLA), killer-cell immunoglobulin-like receptors, etc. To produce this database we have compiled a large collection of datasets from different sources including: (i) peer-reviewed literature, (ii) datasets from international workshops in immunogenetics and histocompatiblity and (iii) data submitted directly to AFND by individual laboratories. As more than 75% of the submissions in AFND are derived from peer-review literature, we rely upon data verification by journal editors and reviewers when source studies are published.
 
 Gonzalez-Galarza FF, McCabe A, Santos EJMD, Jones J, Takeshita L, Ortega-Rivera ND, et al. [Allele frequency net database (AFND) 2020 update: gold-standard data classification, open access genotype data and new query tools.](https://pubmed.ncbi.nlm.nih.gov/31722398/) Nucleic Acids Res. 2020;48: D783–D788. doi:10.1093/nar/gkz1029

--- a/README.md
+++ b/README.md
@@ -379,6 +379,26 @@ https://github.com/emmijokinen/TCRconv
 
 Jokinen E, Dumitrescu A, Huuhtanen J, Gligorijević V, Mustjoki S, Bonneau R, et al. [TCRconv: predicting recognition between T cell receptors and epitopes using contextualized motifs.](https://pubmed.ncbi.nlm.nih.gov/36477794/) Bioinformatics. 2023;39. doi:10.1093/bioinformatics/btac788
 
+### TCRconvert
+
+Python package
+
+https://github.com/seshadrilab/tcrconvert
+
+> TCRconvert converts T cell receptor (TCR) gene names between the 10X, Adaptive, and IMGT naming conventions. It supports alpha-beta and gamma-delta TCRs for human, mouse, and rhesus macaque.
+
+Manuscript in preparation.
+
+### TCRconvertR
+
+R package
+
+https://github.com/seshadrilab/tcrconvertr
+
+> TCRconvertR converts T cell receptor (TCR) gene names between the 10X, Adaptive, and IMGT naming conventions. It supports alpha-beta and gamma-delta TCRs for human, mouse, and rhesus macaque.
+
+Manuscript in preparation.
+
 ### TCRGP
 
 Python scripts


### PR DESCRIPTION
We just released v1.0 of each of these tools, now available on [PyPI](https://pypi.org/project/tcrconvert/) and [CRAN](https://cran.r-project.org/web/packages/TCRconvertR/index.html). 